### PR TITLE
Feature/append httpstatus code in metric key

### DIFF
--- a/spring-service-response-time-metrics-project/changelog.md
+++ b/spring-service-response-time-metrics-project/changelog.md
@@ -1,7 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [1.0.1] - TBC
+
+## [1.1.1] - 
+### Changed
+- Append httpStatusCode for the metric hash map key
+
+
+## [1.0.1] - 
 ### Changed
 - Thread-safe by change from Hashmap to ConcurrentHashMap
 

--- a/spring-service-response-time-metrics-project/changelog.md
+++ b/spring-service-response-time-metrics-project/changelog.md
@@ -2,10 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
-## [1.1.1] - 
+## [1.1.1] - 2019-02-18
 ### Changed
 - Append httpStatusCode for the metric hash map key
 
+## [1.1.0] - 2019-01-24
+### Changed
+- Change handle exception due to NullPointerException in case of request timeout
+- Fix missing HTTP request method in metric
 
 ## [1.0.1] - 
 ### Changed

--- a/spring-service-response-time-metrics-project/pom.xml
+++ b/spring-service-response-time-metrics-project/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.ascendcorp</groupId>
 	<artifactId>spring-service-response-time-metrics</artifactId>
-	<version>1.1.0</version>
+	<version>1.1.1</version>
 	<packaging>jar</packaging>
 
 	<name>spring-service-response-time-metrics</name>
@@ -42,4 +42,6 @@
 			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 	</dependencies>
+
+
 </project>

--- a/spring-service-response-time-metrics-project/src/main/java/com/ascendcorp/spring/serviceresponsetimemetrics/configuration/MetricInfo.java
+++ b/spring-service-response-time-metrics-project/src/main/java/com/ascendcorp/spring/serviceresponsetimemetrics/configuration/MetricInfo.java
@@ -14,7 +14,7 @@ public class MetricInfo {
 
     private HttpMethod httpMethod;
     private String endpoint;
-    private int httpStatus;
+    private int httpStatusCode;
     private long durationInMilliSec;
 
 }

--- a/spring-service-response-time-metrics-project/src/main/java/com/ascendcorp/spring/serviceresponsetimemetrics/configuration/MetricPublisherConfig.java
+++ b/spring-service-response-time-metrics-project/src/main/java/com/ascendcorp/spring/serviceresponsetimemetrics/configuration/MetricPublisherConfig.java
@@ -19,11 +19,11 @@ public class MetricPublisherConfig {
     }
 
     public static void publish(MetricInfo metricInfo) {
-        String metricInfoKey = metricInfo.getHttpMethod().toString() + metricInfo.getEndpoint();
+        String metricInfoKey = metricInfo.getHttpStatusCode() + metricInfo.getHttpMethod().toString() + metricInfo.getEndpoint();
         metricInfoMap.put(metricInfoKey, metricInfo);
         ToDoubleFunction referenceMethod = (value) -> instance.getDurationInMilliSec(metricInfoKey);
 
-        Metrics.gauge(NAME_RESPONSE_TIME_MS, Tags.of("status", Integer.toString(metricInfo.getHttpStatus()), "method", metricInfo.getHttpMethod().toString(), "uri", metricInfo.getEndpoint()), instance, referenceMethod);
+        Metrics.gauge(NAME_RESPONSE_TIME_MS, Tags.of("status", Integer.toString(metricInfo.getHttpStatusCode()), "method", metricInfo.getHttpMethod().toString(), "uri", metricInfo.getEndpoint()), instance, referenceMethod);
     }
 
     private Long getDurationInMilliSec(String key) {


### PR DESCRIPTION
Fix bug report, overlapping metric with difference httpstatus code. Fix by append the httpstatus code as a part of Hashmap key